### PR TITLE
fix: handle optional field values when no field factory passed

### DIFF
--- a/src/factory.ts
+++ b/src/factory.ts
@@ -45,6 +45,18 @@ export class FactoryT<D extends object, O = unknown> {
         }
 
         this.itemsCount++;
+        (Object.keys(partial) as Array<keyof D>).forEach((k) => {
+            if (this.fieldFactoryByKey[k]) {
+                return;
+            }
+            // we can get here, if three conditions occur:
+            // 1. k - optional field
+            // 2. field factory not provided for this field(TS allow this only for optional fields)
+            // 3. partial[k] was passed to item() method (TS should check valid type of this value)
+            // In this case we just assign this value to result object
+            // Source issue #110
+            obj[k] = partial[k] as D[keyof D];
+        });
 
         return obj;
     }

--- a/src/tests/factory-t.test.ts
+++ b/src/tests/factory-t.test.ts
@@ -39,7 +39,7 @@ describe(`${FactoryT.name}`, () => {
         it('handle optional property value when field factory not provided', () => {
             interface WithOptional {
                 name: string;
-                password?: string;
+                optional?: string;
             }
             const factory = factoryT<WithOptional>({
                 name: 'hello',
@@ -48,9 +48,9 @@ describe(`${FactoryT.name}`, () => {
             expect(factory.item()).toStrictEqual({
                 name: 'hello',
             });
-            expect(factory.item({ password: 'pass-value' })).toStrictEqual({
+            expect(factory.item({ optional: 'optional-value' })).toStrictEqual({
                 name: 'hello',
-                password: 'pass-value',
+                optional: 'optional-value',
             });
         });
 

--- a/src/tests/factory-t.test.ts
+++ b/src/tests/factory-t.test.ts
@@ -36,6 +36,24 @@ describe(`${FactoryT.name}`, () => {
             });
         });
 
+        it('handle optional property value when field factory not provided', () => {
+            interface WithOptional {
+                name: string;
+                password?: string;
+            }
+            const factory = factoryT<WithOptional>({
+                name: 'hello',
+            });
+
+            expect(factory.item()).toStrictEqual({
+                name: 'hello',
+            });
+            expect(factory.item({ password: 'pass-value' })).toStrictEqual({
+                name: 'hello',
+                password: 'pass-value',
+            });
+        });
+
         it('resolve props dependencies', () => {
             const factory = factoryTBuilder<{
                 C: string;


### PR DESCRIPTION
The fix makes a working case when 
- optional field factory not provided (because of optional)
- but value for this field passed to `.item({...})` method and should be assign to generated object
Should fix #110 

```ts
            interface WithOptional {
                name: string;
                password?: string;
            }
            const factory = factoryT<WithOptional>({
                name: 'hello',
            });

            expect(factory.item()).toStrictEqual({
                name: 'hello',
            });
            expect(factory.item({ password: 'pass-value' })).toStrictEqual({
                name: 'hello',
                password: 'pass-value',
            });
```